### PR TITLE
Ensure correct migration order

### DIFF
--- a/ModuleMigration.php
+++ b/ModuleMigration.php
@@ -61,6 +61,7 @@ class ModuleMigration extends MigrateController
             $result = array_merge($result, parent::getNewMigrations());
         }
         $this->migrationPath = $this->allMigrationPaths['app'];
+        sort($result);
         return $result;
     }
 


### PR DESCRIPTION
apply migrations in the order they where created.

Currently migrations get applied kind of randomly/dependend on directory structure.